### PR TITLE
fix: remaining_groups must only include not-yet-shown stages

### DIFF
--- a/pipeline/pipeline.sh
+++ b/pipeline/pipeline.sh
@@ -300,7 +300,7 @@ main() {
     # Must run after config sourcing so SFM_PIPELINE overrides are respected.
     {
         local _pipeline="${SFM_PIPELINE:-colmap-openmvs-sparse}"
-        echo -n "::remaining_groups::Config,Tool Discovery"
+        echo -n "::remaining_groups::"
         while IFS= read -r _stage_file; do
             local _display_name
             _display_name=$(grep -m1 '^DISPLAY_NAME=' "$_stage_file" 2>/dev/null | cut -d= -f2 | tr -d '"' || basename "$_stage_file" .stage.sh)


### PR DESCRIPTION
The `::remaining_groups::` annotation was computed at the top level before `config.sh` was sourced, so if `SFM_PIPELINE` was overridden in `config.sh` the annotation would show stages from the wrong pipeline.\n\nAlso, Config and Tool Discovery groups are already displayed via `::group`/`::endgroup` before this annotation runs, so they should not appear in remaining_groups.