### PR TITLE
fix: keyframe cache never hits due to oldest_frame_mtime initialized to 0

### DIFF
--- a/pipeline/discover.sh
+++ b/pipeline/discover.sh
@@ -271,7 +271,6 @@ get_custom_var_names() {
 
 get_custom_var_help() {
     local var="$1"
-
     awk -v var="$var" '
         /^BEGIN_VAR$/ {
             getline name

--- a/pipeline/stages/common/00_extract_keyframes.stage.sh
+++ b/pipeline/stages/common/00_extract_keyframes.stage.sh
@@ -34,7 +34,7 @@ run_stage_function() {
         # Check if frames for this video already exist and are up-to-date
         local video_mtime
         video_mtime=$(stat -c '%Y' "$video")
-        local oldest_frame_mtime=0
+        local oldest_frame_mtime=9999999999
         local has_frames=0
         for f in "${IMAGES_DIR}/${video_name}_frame_"*; do
             if [[ -f "$f" ]]; then


### PR DESCRIPTION
## Problem

`oldest_frame_mtime` was initialized to `0` in the keyframe extraction cache check. Since Unix file timestamps are always positive (~1.7 billion), the comparison `mtime < oldest_frame_mtime` was **always false**, so the variable never updated from `0`. This made the cache freshness check `[[ 0 -ge \ ]]` always fail, forcing a re-extraction every run.

## Fix

Initialize `oldest_frame_mtime` to `9999999999` so the first encountered frame's mtime correctly sets the minimum.

```diff
- local oldest_frame_mtime=0
+ local oldest_frame_mtime=9999999999
```

## Validation

All per-pipeline stage files are symlinks to `pipeline/stages/common/00_extract_keyframes.stage.sh`, so this single change propagates to all pipeline variants.